### PR TITLE
Reflect specification location to query param url

### DIFF
--- a/src/components/UriInput.tsx
+++ b/src/components/UriInput.tsx
@@ -21,6 +21,9 @@ const UriInput: FC<Props> = ({ onSubmit }) => {
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = event => {
     event.preventDefault();
+    const newUrl = new URL(window.location.href);
+    newUrl.searchParams.set('url', uri);
+    history.pushState({}, '', newUrl.href);
     onSubmit(uri);
   };
 


### PR DESCRIPTION
Whenever a specification is loaded, the url is now also updated with the new url as query parameter.

Fixes #4 